### PR TITLE
Improve coping plan syncing and follow-up generation

### DIFF
--- a/client/src/components/cognitive-distortion-analysis.tsx
+++ b/client/src/components/cognitive-distortion-analysis.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Brain, AlertTriangle } from "lucide-react";
@@ -8,12 +9,14 @@ interface CognitiveDistortionAnalysisProps {
   thoughts: string;
   situation: string;
   evidence: string;
+  onDistortionsChange?: (distortions: CognitiveDistortion[]) => void;
 }
 
 export default function CognitiveDistortionAnalysis({
   thoughts,
   situation,
-  evidence
+  evidence,
+  onDistortionsChange
 }: CognitiveDistortionAnalysisProps) {
   const { data: distortions, isLoading } = useQuery<CognitiveDistortion[]>({
     queryKey: ["/api/analyze-distortions", thoughts, situation, evidence],
@@ -31,6 +34,12 @@ export default function CognitiveDistortionAnalysis({
     },
     enabled: !!thoughts.trim(),
   });
+
+  useEffect(() => {
+    if (onDistortionsChange) {
+      onDistortionsChange(distortions ?? []);
+    }
+  }, [distortions, onDistortionsChange]);
 
   const getDistortionLabel = (type: string): string => {
     const labels = {

--- a/client/src/components/records-list.tsx
+++ b/client/src/components/records-list.tsx
@@ -1,4 +1,4 @@
-import { AngerRecord, Emotion, CognitiveDistortion } from "@shared/schema";
+import { AngerRecord, Emotion, CognitiveDistortion, CopingPlan, FollowUpReview } from "@shared/schema";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ChevronRight } from "lucide-react";
@@ -234,6 +234,104 @@ export default function RecordsList({ records, isLoading, filterPeriod, filterEm
                     );
                   } catch {
                     return <p className="text-sm text-gray-500">分析データなし</p>;
+                  }
+                })()}
+              </div>
+
+              <div>
+                <h4 className="font-semibold mb-2">対処プラン</h4>
+                {(() => {
+                  try {
+                    const plans = JSON.parse(selectedRecord.copingPlans) as CopingPlan[];
+                    if (!plans || plans.length === 0) {
+                      return <p className="text-sm text-gray-500">登録された対処プランはありません。</p>;
+                    }
+
+                    return (
+                      <div className="space-y-2">
+                        {plans.map((plan) => (
+                          <div key={plan.id} className="rounded-lg border border-orange-200 bg-orange-50 p-3">
+                            <div className="flex items-center justify-between">
+                              <span className="font-medium text-gray-800">
+                                {getDistortionLabel(plan.distortionType)}
+                              </span>
+                              {plan.willTry ? (
+                                <Badge variant="outline" className="border-orange-300 text-orange-700">
+                                  実行予定
+                                </Badge>
+                              ) : null}
+                            </div>
+                            <p className="mt-2 text-sm text-gray-700 whitespace-pre-line">{plan.action}</p>
+                            {plan.supportNotes && (
+                              <p className="mt-2 text-xs text-gray-500">補足: {plan.supportNotes}</p>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    );
+                  } catch {
+                    return <p className="text-sm text-gray-500">プラン情報を読み取れませんでした。</p>;
+                  }
+                })()}
+              </div>
+
+              <div>
+                <h4 className="font-semibold mb-2">フォローアップ</h4>
+                {(() => {
+                  if (!selectedRecord.followUpReview) {
+                    return <p className="text-sm text-gray-500">フォローアップ記録はまだありません。</p>;
+                  }
+
+                  try {
+                    const review = JSON.parse(selectedRecord.followUpReview) as FollowUpReview;
+                    if (!review || !review.items || review.items.length === 0) {
+                      return <p className="text-sm text-gray-500">フォローアップ記録はまだありません。</p>;
+                    }
+
+                    const planLookup = (() => {
+                      try {
+                        const plans = JSON.parse(selectedRecord.copingPlans) as CopingPlan[];
+                        return new Map(plans.map((plan) => [plan.id, plan]));
+                      } catch {
+                        return new Map<string, CopingPlan>();
+                      }
+                    })();
+
+                    return (
+                      <div className="space-y-3">
+                        {review.items.map((item) => {
+                          const plan = planLookup.get(item.planId);
+                          return (
+                            <div key={item.planId} className="rounded-lg border border-teal-200 bg-teal-50 p-3">
+                              <div className="flex items-center justify-between">
+                                <div>
+                                  <p className="text-sm font-medium text-gray-700">
+                                    {plan ? getDistortionLabel(plan.distortionType) : "プラン"}
+                                  </p>
+                                  <p className="text-sm text-gray-600 mt-1">{item.planSummary}</p>
+                                </div>
+                                <Badge
+                                  variant="outline"
+                                  className={item.attempted ? "border-teal-300 text-teal-700" : "border-gray-300 text-gray-600"}
+                                >
+                                  {item.attempted ? "実行" : "未実行"}
+                                </Badge>
+                              </div>
+                              {item.notes && (
+                                <p className="mt-2 text-xs text-gray-600 whitespace-pre-line">メモ: {item.notes}</p>
+                              )}
+                            </div>
+                          );
+                        })}
+                        {review.reflection && (
+                          <div className="rounded-lg border border-teal-200 bg-white p-3">
+                            <p className="text-xs text-gray-600 whitespace-pre-line">全体メモ: {review.reflection}</p>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  } catch {
+                    return <p className="text-sm text-gray-500">フォローアップ情報を読み取れませんでした。</p>;
                   }
                 })()}
               </div>

--- a/client/src/components/seven-column-form.tsx
+++ b/client/src/components/seven-column-form.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -10,18 +10,33 @@ import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { insertAngerRecordSchema, type Emotion } from "@shared/schema";
+import {
+  insertAngerRecordSchema,
+  type Emotion,
+  type CognitiveDistortion,
+  type CopingPlan,
+  type FollowUpReview,
+  type AngerRecord,
+  cognitiveDistortionSchema,
+  copingPlanSchema,
+  followUpReviewSchema,
+} from "@shared/schema";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { Edit, Plus, RotateCcw, Save } from "lucide-react";
 import { z } from "zod";
 import CognitiveDistortionAnalysis from "./cognitive-distortion-analysis";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
 
 const formSchema = insertAngerRecordSchema.extend({
   emotions: z.array(z.object({
     type: z.string().min(1, "感情を選択してください"),
     intensity: z.number().min(0).max(100)
-  })).min(1, "少なくとも1つの感情を入力してください")
+  })).min(1, "少なくとも1つの感情を入力してください"),
+  detectedDistortions: z.array(cognitiveDistortionSchema),
+  copingPlans: z.array(copingPlanSchema),
+  followUpReview: followUpReviewSchema.optional().nullable()
 });
 
 type FormData = z.infer<typeof formSchema>;
@@ -32,10 +47,13 @@ export default function SevenColumnForm() {
   ]);
   const [moodBefore, setMoodBefore] = useState(70);
   const [moodAfter, setMoodAfter] = useState(30);
-  
+  const [detectedDistortions, setDetectedDistortions] = useState<CognitiveDistortion[]>([]);
+  const [copingPlans, setCopingPlans] = useState<CopingPlan[]>([]);
+  const [followUpReview, setFollowUpReview] = useState<FollowUpReview | null>(null);
+
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  
+
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -48,9 +66,237 @@ export default function SevenColumnForm() {
       moodBefore,
       moodAfter,
       emotions,
-      detectedDistortions: []
+      detectedDistortions: [],
+      copingPlans: [],
+      followUpReview: null
     }
   });
+
+  const thoughtsValue = form.watch("thoughts");
+  const situationValue = form.watch("situation");
+  const evidenceValue = form.watch("evidence");
+
+  const generatePlanId = () =>
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `plan-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  const getDistortionKey = (distortion: CognitiveDistortion) =>
+    [distortion.type, distortion.description, distortion.suggestion]
+      .map((value) => value.trim().toLowerCase())
+      .join("::");
+
+  const createPlanFromDistortion = (distortion: CognitiveDistortion): CopingPlan => ({
+    id: generatePlanId(),
+    distortionType: distortion.type,
+    suggestion: distortion.suggestion,
+    action: distortion.suggestion,
+    willTry: true,
+    supportNotes: "",
+    distortionKey: getDistortionKey(distortion),
+  });
+
+  const createFollowUpTemplate = (): FollowUpReview | null => {
+    if (!latestRecord || previousCopingPlans.length === 0) return null;
+
+    const actionablePlans = previousCopingPlans.filter((plan) => plan.willTry);
+    if (actionablePlans.length === 0) return null;
+
+    return {
+      previousRecordId: latestRecord.id,
+      items: actionablePlans.map((plan) => ({
+        planId: plan.id,
+        planSummary: plan.action.trim() || plan.suggestion,
+        attempted: false,
+        notes: "",
+      })),
+      reflection: "",
+    };
+  };
+
+  const { data: latestRecord } = useQuery<AngerRecord | null>({
+    queryKey: ["/api/anger-records", "latest"],
+    queryFn: async () => {
+      const response = await fetch("/api/anger-records?limit=1");
+      if (!response.ok) throw new Error("Failed to fetch latest record");
+      const records = await response.json();
+      return Array.isArray(records) && records.length > 0 ? records[0] : null;
+    },
+  });
+
+  const previousCopingPlans = useMemo(() => {
+    if (!latestRecord || !latestRecord.copingPlans) return [] as CopingPlan[];
+    try {
+      const parsed = JSON.parse(latestRecord.copingPlans) as CopingPlan[];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [] as CopingPlan[];
+    }
+  }, [latestRecord]);
+
+  const previousPlanMap = useMemo(() => {
+    return new Map(previousCopingPlans.map((plan) => [plan.id, plan]));
+  }, [previousCopingPlans]);
+
+  useEffect(() => {
+    const template = createFollowUpTemplate();
+
+    if (!template) {
+      if (followUpReview !== null) {
+        setFollowUpReview(null);
+        form.setValue("followUpReview", null, { shouldDirty: false });
+      }
+      return;
+    }
+
+    if (!followUpReview || followUpReview.previousRecordId !== template.previousRecordId) {
+      setFollowUpReview(template);
+      form.setValue("followUpReview", template, { shouldDirty: false });
+    }
+  }, [latestRecord, previousCopingPlans, followUpReview, form]);
+
+  const getDistortionLabel = (type: string): string => {
+    const labels: Record<string, string> = {
+      labeling: "ラベリング",
+      mind_reading: "読心",
+      all_or_nothing: "白黒思考",
+      personalization: "個人化",
+      externalization: "外部化",
+    };
+
+    return labels[type] ?? type;
+  };
+
+  const syncCopingPlans = (updater: (plans: CopingPlan[]) => CopingPlan[]) => {
+    setCopingPlans((prev) => {
+      const next = updater(prev);
+      form.setValue("copingPlans", next, { shouldDirty: true });
+      return next;
+    });
+  };
+
+  const handleDistortionsChange = (distortions: CognitiveDistortion[]) => {
+    setDetectedDistortions(distortions);
+    form.setValue("detectedDistortions", distortions, { shouldDirty: true });
+
+    syncCopingPlans((prevPlans) => {
+      const planMap = new Map<string, CopingPlan>();
+
+      prevPlans.forEach((plan) => {
+        const key = plan.distortionKey ?? `${plan.distortionType}::${plan.suggestion}`;
+        planMap.set(key, plan);
+        if (!plan.distortionKey) {
+          planMap.set(plan.distortionType, plan);
+        }
+      });
+
+      return distortions.map((distortion) => {
+        const key = getDistortionKey(distortion);
+        const existing = planMap.get(key) ?? planMap.get(distortion.type);
+
+        if (existing) {
+          const suggestionChanged = existing.suggestion !== distortion.suggestion;
+          const shouldUpdateAction = suggestionChanged && existing.action.trim() === existing.suggestion.trim();
+
+          return {
+            ...existing,
+            distortionType: distortion.type,
+            suggestion: distortion.suggestion,
+            distortionKey: key,
+            action: shouldUpdateAction ? distortion.suggestion : existing.action,
+          };
+        }
+
+        return createPlanFromDistortion(distortion);
+      });
+    });
+  };
+
+  const handlePlanActionChange = (planId: string, value: string) => {
+    syncCopingPlans((plans) =>
+      plans.map((plan) => (plan.id === planId ? { ...plan, action: value } : plan))
+    );
+  };
+
+  const handlePlanWillTryChange = (planId: string, willTry: boolean) => {
+    syncCopingPlans((plans) =>
+      plans.map((plan) => (plan.id === planId ? { ...plan, willTry } : plan))
+    );
+  };
+
+  const handlePlanSupportNotesChange = (planId: string, value: string) => {
+    syncCopingPlans((plans) =>
+      plans.map((plan) => (plan.id === planId ? { ...plan, supportNotes: value } : plan))
+    );
+  };
+
+  const syncFollowUpReview = (
+    updater: (review: FollowUpReview | null) => FollowUpReview | null
+  ) => {
+    setFollowUpReview((prev) => {
+      const next = updater(prev);
+      form.setValue("followUpReview", next, { shouldDirty: true });
+      return next;
+    });
+  };
+
+  const handleFollowUpAttemptedChange = (planId: string, attempted: boolean) => {
+    syncFollowUpReview((review) => {
+      if (!review) return review;
+      return {
+        ...review,
+        items: review.items.map((item) =>
+          item.planId === planId ? { ...item, attempted } : item
+        ),
+      };
+    });
+  };
+
+  const handleFollowUpNotesChange = (planId: string, value: string) => {
+    syncFollowUpReview((review) => {
+      if (!review) return review;
+      return {
+        ...review,
+        items: review.items.map((item) =>
+          item.planId === planId ? { ...item, notes: value } : item
+        ),
+      };
+    });
+  };
+
+  const handleFollowUpReflectionChange = (value: string) => {
+    syncFollowUpReview((review) => {
+      if (!review) return review;
+      return { ...review, reflection: value };
+    });
+  };
+
+  const resetFormState = () => {
+    const defaultEmotions: Emotion[] = [{ type: "怒り", intensity: 50 }];
+    const followUpTemplate = createFollowUpTemplate();
+
+    form.reset({
+      date: new Date().toISOString().split("T")[0],
+      situation: "",
+      thoughts: "",
+      evidence: "",
+      counterEvidence: "",
+      balancedThinking: "",
+      moodBefore: 70,
+      moodAfter: 30,
+      emotions: defaultEmotions,
+      detectedDistortions: [],
+      copingPlans: [],
+      followUpReview: followUpTemplate,
+    });
+
+    setEmotions(defaultEmotions);
+    setMoodBefore(70);
+    setMoodAfter(30);
+    setDetectedDistortions([]);
+    setCopingPlans([]);
+    setFollowUpReview(followUpTemplate);
+  };
 
   const mutation = useMutation({
     mutationFn: async (data: FormData) => {
@@ -64,10 +310,8 @@ export default function SevenColumnForm() {
       });
       queryClient.invalidateQueries({ queryKey: ["/api/anger-records"] });
       queryClient.invalidateQueries({ queryKey: ["/api/stats"] });
-      form.reset();
-      setEmotions([{ type: "怒り", intensity: 50 }]);
-      setMoodBefore(70);
-      setMoodAfter(30);
+      queryClient.invalidateQueries({ queryKey: ["/api/anger-records", "latest"] });
+      resetFormState();
     },
     onError: () => {
       toast({
@@ -79,11 +323,19 @@ export default function SevenColumnForm() {
   });
 
   const onSubmit = (data: FormData) => {
+    const selectedPlans = copingPlans.filter((plan) => plan.willTry);
+    const reviewToSave = followUpReview && followUpReview.items.length > 0
+      ? followUpReview
+      : null;
+
     mutation.mutate({
       ...data,
       emotions,
       moodBefore,
-      moodAfter
+      moodAfter,
+      detectedDistortions,
+      copingPlans: selectedPlans,
+      followUpReview: reviewToSave
     });
   };
 
@@ -101,13 +353,6 @@ export default function SevenColumnForm() {
     if (emotions.length > 1) {
       setEmotions(emotions.filter((_, i) => i !== index));
     }
-  };
-
-  const resetForm = () => {
-    form.reset();
-    setEmotions([{ type: "怒り", intensity: 50 }]);
-    setMoodBefore(70);
-    setMoodAfter(30);
   };
 
   const improvement = Math.round(((moodBefore - moodAfter) / moodBefore) * 100);
@@ -410,11 +655,180 @@ export default function SevenColumnForm() {
             </div>
 
             {/* Cognitive Distortion Analysis */}
-            <CognitiveDistortionAnalysis 
-              thoughts={form.watch("thoughts")}
-              situation={form.watch("situation")}
-              evidence={form.watch("evidence")}
+            <CognitiveDistortionAnalysis
+              thoughts={thoughtsValue}
+              situation={situationValue}
+              evidence={evidenceValue}
+              onDistortionsChange={handleDistortionsChange}
             />
+
+            {/* Coping Plans */}
+            <div className="rounded-lg border border-orange-100 bg-warm p-6 space-y-4">
+              <div className="flex items-start gap-3">
+                <span className="text-xl">🧭</span>
+                <div>
+                  <h4 className="text-base font-semibold text-gray-900">対処プラン</h4>
+                  <p className="text-sm text-gray-600 mt-1">
+                    AIが検出した認知の歪みに合わせて、実践したい行動プランを整理しましょう。
+                  </p>
+                </div>
+              </div>
+
+              {detectedDistortions.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-orange-200 bg-white p-4 text-sm text-gray-600">
+                  自動思考を入力すると、ここにおすすめの対処プランを作成できます。
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {copingPlans.map((plan) => (
+                    <div
+                      key={plan.id}
+                      className="space-y-4 rounded-lg border border-orange-200 bg-white p-4 shadow-sm"
+                    >
+                      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge
+                            variant="outline"
+                            className="border-orange-200 bg-orange-50 text-orange-700"
+                          >
+                            {getDistortionLabel(plan.distortionType)}
+                          </Badge>
+                          <span className="text-xs text-gray-500">
+                            ヒント: {plan.suggestion}
+                          </span>
+                        </div>
+                        <div className="flex items-center space-x-2">
+                          <Checkbox
+                            id={`plan-try-${plan.id}`}
+                            checked={plan.willTry}
+                            onCheckedChange={(checked) =>
+                              handlePlanWillTryChange(plan.id, checked === true)
+                            }
+                          />
+                          <Label htmlFor={`plan-try-${plan.id}`} className="text-sm text-gray-700">
+                            今回このプランに取り組む
+                          </Label>
+                        </div>
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label htmlFor={`plan-action-${plan.id}`} className="text-sm font-medium text-gray-700">
+                          行動プランの内容
+                        </Label>
+                        <Textarea
+                          id={`plan-action-${plan.id}`}
+                          value={plan.action}
+                          onChange={(event) => handlePlanActionChange(plan.id, event.target.value)}
+                          placeholder="例：相手の意図を確認してから返答する、深呼吸を3回してから話す"
+                          className="min-h-[80px]"
+                        />
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label htmlFor={`plan-notes-${plan.id}`} className="text-xs font-medium text-gray-500">
+                          サポートや準備メモ（任意）
+                        </Label>
+                        <Textarea
+                          id={`plan-notes-${plan.id}`}
+                          value={plan.supportNotes ?? ""}
+                          onChange={(event) => handlePlanSupportNotesChange(plan.id, event.target.value)}
+                          placeholder="例：同僚に相談する、事前に資料を読み込んでおく"
+                          className="min-h-[60px]"
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Follow-up */}
+            <div className="rounded-lg border border-teal-100 bg-teal-50 p-6 space-y-4">
+              <div className="flex items-start gap-3">
+                <span className="text-xl">🔁</span>
+                <div>
+                  <h4 className="text-base font-semibold text-gray-900">フォローアップ</h4>
+                  <p className="text-sm text-teal-700 mt-1">
+                    前回の記録で立てたプランが実践できたかを振り返りましょう。
+                  </p>
+                </div>
+              </div>
+
+              {followUpReview && followUpReview.items.length > 0 && latestRecord ? (
+                <div className="space-y-4">
+                  <p className="text-xs text-teal-700">
+                    対象の記録: {latestRecord.date} の対処プラン
+                  </p>
+                  {followUpReview.items.map((item) => {
+                    const basePlan = previousPlanMap.get(item.planId);
+                    return (
+                      <div
+                        key={item.planId}
+                        className="space-y-3 rounded-lg border border-teal-200 bg-white p-4"
+                      >
+                        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                          <div className="flex flex-wrap items-center gap-2">
+                            {basePlan && (
+                              <Badge
+                                variant="outline"
+                                className="border-teal-200 bg-teal-50 text-teal-700"
+                              >
+                                {getDistortionLabel(basePlan.distortionType)}
+                              </Badge>
+                            )}
+                            <span className="text-sm text-gray-700">
+                              {item.planSummary}
+                            </span>
+                          </div>
+                          <div className="flex items-center space-x-2">
+                            <Checkbox
+                              id={`follow-up-${item.planId}`}
+                              checked={item.attempted}
+                              onCheckedChange={(checked) =>
+                                handleFollowUpAttemptedChange(item.planId, checked === true)
+                              }
+                            />
+                            <Label htmlFor={`follow-up-${item.planId}`} className="text-sm text-gray-700">
+                              試せた
+                            </Label>
+                          </div>
+                        </div>
+
+                        <div className="space-y-2">
+                          <Label htmlFor={`follow-up-notes-${item.planId}`} className="text-xs font-medium text-gray-500">
+                            メモ（結果や気づき）
+                          </Label>
+                          <Textarea
+                            id={`follow-up-notes-${item.planId}`}
+                            value={item.notes ?? ""}
+                            onChange={(event) => handleFollowUpNotesChange(item.planId, event.target.value)}
+                            placeholder="例：半分だけ実行できた／次回の課題 など"
+                            className="min-h-[60px]"
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+
+                  <div className="space-y-2">
+                    <Label htmlFor="follow-up-reflection" className="text-sm font-medium text-gray-700">
+                      全体の振り返りメモ（任意）
+                    </Label>
+                    <Textarea
+                      id="follow-up-reflection"
+                      value={followUpReview.reflection ?? ""}
+                      onChange={(event) => handleFollowUpReflectionChange(event.target.value)}
+                      placeholder="プランを実践してみて感じたことや次回の工夫を書き残しましょう"
+                      className="min-h-[80px]"
+                    />
+                  </div>
+                </div>
+              ) : (
+                <div className="rounded-lg border border-dashed border-teal-200 bg-white p-4 text-sm text-gray-600">
+                  前回の記録で対処プランを保存すると、ここで振り返りができます。
+                </div>
+              )}
+            </div>
 
             {/* Form Actions */}
             <div className="flex flex-col sm:flex-row gap-4 pt-6 border-t border-gray-200">
@@ -426,11 +840,11 @@ export default function SevenColumnForm() {
                 <Save className="h-4 w-4 mr-2" />
                 {mutation.isPending ? "保存中..." : "記録を保存"}
               </Button>
-              <Button 
-                type="button" 
-                variant="outline" 
-                className="flex-1" 
-                onClick={resetForm}
+              <Button
+                type="button"
+                variant="outline"
+                className="flex-1"
+                onClick={resetFormState}
               >
                 <RotateCcw className="h-4 w-4 mr-2" />
                 リセット

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -68,6 +68,10 @@ export class MemStorage implements IStorage {
       id,
       emotions: JSON.stringify(insertRecord.emotions),
       detectedDistortions: JSON.stringify(insertRecord.detectedDistortions),
+      copingPlans: JSON.stringify(insertRecord.copingPlans ?? []),
+      followUpReview: insertRecord.followUpReview
+        ? JSON.stringify(insertRecord.followUpReview)
+        : null,
       createdAt: new Date(),
     };
     this.angerRecords.set(id, record);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, boolean, timestamp, real } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, integer, timestamp } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -14,6 +14,8 @@ export const angerRecords = pgTable("anger_records", {
   moodBefore: integer("mood_before").notNull(), // 0-100 scale
   moodAfter: integer("mood_after").notNull(), // 0-100 scale
   detectedDistortions: text("detected_distortions").notNull(), // JSON string of distortion objects
+  copingPlans: text("coping_plans").notNull(), // JSON string of coping plan objects
+  followUpReview: text("follow_up_review"), // JSON string of follow-up review data
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
@@ -28,9 +30,34 @@ export const cognitiveDistortionSchema = z.object({
   suggestion: z.string(),
 });
 
+export const copingPlanSchema = z.object({
+  id: z.string(),
+  distortionType: z.string(),
+  suggestion: z.string(),
+  action: z.string().min(1, "行動プランを入力してください"),
+  willTry: z.boolean(),
+  supportNotes: z.string().optional(),
+  distortionKey: z.string().optional(),
+});
+
+export const followUpItemSchema = z.object({
+  planId: z.string(),
+  planSummary: z.string(),
+  attempted: z.boolean(),
+  notes: z.string().optional(),
+});
+
+export const followUpReviewSchema = z.object({
+  previousRecordId: z.number(),
+  items: z.array(followUpItemSchema),
+  reflection: z.string().optional(),
+});
+
 export const insertAngerRecordSchema = createInsertSchema(angerRecords, {
   emotions: z.array(emotionSchema),
   detectedDistortions: z.array(cognitiveDistortionSchema),
+  copingPlans: z.array(copingPlanSchema).default([]),
+  followUpReview: followUpReviewSchema.optional().nullable(),
 }).omit({
   id: true,
   createdAt: true,
@@ -40,3 +67,6 @@ export type InsertAngerRecord = z.infer<typeof insertAngerRecordSchema>;
 export type AngerRecord = typeof angerRecords.$inferSelect;
 export type Emotion = z.infer<typeof emotionSchema>;
 export type CognitiveDistortion = z.infer<typeof cognitiveDistortionSchema>;
+export type CopingPlan = z.infer<typeof copingPlanSchema>;
+export type FollowUpReview = z.infer<typeof followUpReviewSchema>;
+export type FollowUpItem = z.infer<typeof followUpItemSchema>;


### PR DESCRIPTION
## Summary
- add stable distortion keys to coping plans so user edits persist across re-analyses
- only build follow-up templates from actionable plans and preserve user-written summaries
- default follow-up summaries to the saved action text or suggestion for clarity

## Testing
- npm run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912d8dafac4832a9e2da72150f21119)